### PR TITLE
Fix ws feed bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,16 @@ or you can directly type
 yarn ios
 ```
 to run iOS simulator
+
+Notes for Debian-based systems && Android:
+
+1) Upgrade to last npm version:
+```
+npm install -g npm@latest
+```
+2) If network error on login: Comment condition in NetworkReducer.js:
+  return {
+    isConnected: true
+  }
+
+3) Install expo app on Android 

--- a/src/config/axios.js
+++ b/src/config/axios.js
@@ -12,6 +12,7 @@ const getAxiosInstance = async (optionalHeaders = {}) => {
           'Uid': secretData.uid,
           'Access-Token': secretData['access-token'],
           'Client': secretData.client,
+          'Client-Type': 'mobile',
           ...optionalHeaders
         }
       }

--- a/src/operations/FeedOperations.js
+++ b/src/operations/FeedOperations.js
@@ -88,7 +88,7 @@ const reportPost = (postId, cb) => {
 }
 
 const blockUser = (userId, cb) => {
-  return dispatch => { 
+  return dispatch => {
 
     return getAxiosInstance().then(api => {
       api.post(`${API_URL}/profiles/${userId}/block`)
@@ -102,7 +102,7 @@ const blockUser = (userId, cb) => {
 
 const deletePost = (postId, cb) => {
   return dispatch => {
-    
+
     return getAxiosInstance().then(api => {
       api.delete(`${API_URL}/stories/${postId}`)
         .then(response => {
@@ -147,7 +147,10 @@ const connectToWs = () => {
   return dispatch => {
     return cable.then(cable_instance => {
       feedConnection = cable_instance.subscriptions.create(
-        'FeedChannel',
+        {
+         channel: 'FeedChannel',
+         client_type: 'mobile'
+        },
         {
           received: (data) => {
             if (data.type === 'story') {


### PR DESCRIPTION
В текущей логике плексы 'Client-Type'обязателен для некоторых enpointoв
Он нужен для разделения websocket клиентов и сохранения текущего фида в редисе

Т.к 'Client-Type' не отсылался => то у текущего юзера "как бы не было данной стори в редисе" => ему и не broadcast-илось( что логично)

Можно полностью отказаться от client_type, заменив его например на ip адресс.( т.е на фронте вообще ничего не отсылать).И использовать ip_address как идентификатор клиента к ws. Но я бы предложил посоветоваться в общем чате т.к. я не уверен на 100%.